### PR TITLE
CSS 修正~ ログイン画面＆新規登録画面

### DIFF
--- a/app/assets/stylesheets/_flex_settings.scss
+++ b/app/assets/stylesheets/_flex_settings.scss
@@ -21,6 +21,7 @@
  	-webkit-justify-content: flex-space-between;
     justify-content: flex-space-between;
  }
+ 
 //要素を均等に配置し,隙間を埋めます
  .flex-start{
  	display:-webkit-flex;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,10 +15,10 @@
  */
 
 
-
+@import "reset"; 
 @import "flex_settings";
 @import "colors";
-@import "reset";
+
 
 @import "uikit/src/scss/variables.scss";
 @import "uikit/src/scss/mixins.scss";
@@ -60,6 +60,11 @@ header{
 	}
 }
 
+form{
+	width:100%;
+	padding:16px;
+	max-width: 500px;
+}
 
 // FOOTER設定用Style
 footer{

--- a/app/assets/stylesheets/form.scss
+++ b/app/assets/stylesheets/form.scss
@@ -1,25 +1,33 @@
+
+
 .form-title{
   font-size: 3vh;
   margin: 16px 0;
 }
 
 .field{
-  height: 8vh;
+  width:100%;
+  .uk-inline{
+    width:100%;
+  }
+
   &-input{
-    min-width: 50vw;
-    height: 4vh !important;
+    width:100%;
+    height: 5vh !important;
     line-height: 5vh;
   }
   &-label{
+    width:100%;
     font-size: 1.5vh;
     padding: 4px 0;
   }
 }
-
+.actions{
+  margin:32px 0;
+}
 .form-button{
   font-size: 2vh;
-  width: 20vw;
-  height: 5vh;
+  width: 100%;
 }
 
 .warning{

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -1,10 +1,12 @@
-%h2 Forgot your password?
-= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
-  = devise_error_messages!
-  .field
-    = f.label :email
-    %br/
-    = f.email_field :email, autofocus: true, autocomplete: "email"
-  .actions
-    = f.submit "Send me reset password instructions"
-= render "devise/shared/links"
+.flex-center
+	= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
+		%legend.uk-legend.form-title パスワードのリセット
+		= devise_error_messages!
+		.field
+			= f.label :email
+			.uk-inline
+				%span.uk-form-icon.uk-form-icon-flip{"uk-icon" => "icon: mail"}
+				= f.email_field :email, autofocus: true, autocomplete: "email", class: "uk-input field-input"
+		.actions
+		= f.submit "パスワードをリセットする", class: "uk-button uk-button-danger form-button"
+		= render "devise/shared/links"

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -45,4 +45,4 @@
           = content_tag(:option, c.first, value: c.last)
     .actions.flex-center
       = f.submit "登録", class: "uk-button uk-button-primary form-button"
-= render "devise/shared/links"
+    = render "devise/shared/links"

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -17,6 +17,6 @@
           = f.check_box :remember_me, class: "uk-checkbox"   
           %span{style:'font-size:1.5vh'} 次回からログインを省略
     .actions.flex-center
-      = f.submit "Log in",class: "uk-button uk-button-primary form-button"
+      = f.submit "ログイン",class: "uk-button uk-button-primary form-button"
 
     = render "devise/shared/links"

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,5 +1,5 @@
 .flex-center.flex-column
-  = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
+  = form_for resource, as: resource_name, url: session_path(resource_name), class: 'form'  do |f|
     %legend.uk-legend.form-title ログイン
     .field
       = f.label :email, class: "field-label"
@@ -15,8 +15,8 @@
       .field
         .uk-inline
           = f.check_box :remember_me, class: "uk-checkbox"   
-          %span{style:'font-size:1.5vh'} 次回から自動ログイン
+          %span{style:'font-size:1.5vh'} 次回からログインを省略
     .actions.flex-center
       = f.submit "Log in",class: "uk-button uk-button-primary form-button"
 
-= render "devise/shared/links"
+    = render "devise/shared/links"


### PR DESCRIPTION
Formについて変更しました。
・Formは、できれば大きめのDIVで囲ってあげて、そいつにWidthを設定して、あとの子要素は特別なことがない限りWidth:100%；に設定する。paddingはFormのDIVに設定してあげることで、横の端が揃う。
・子要素の高さはpaddingやmarginで”自然に”設定する。Heightはデフォルトのautoにしておく。heightを指定してしまうと、Paddingの設定によって見切れたりする。
・FormなどはスマホはWidth:100％、でもパソコンだとでかすぎる場合、max-widthなどで設定して、ブラウザが広がった時に綺麗に画面に収まるようにする。

以上、確認の上Mergeお願いします。
