### PR TITLE
メニュー表示機能実装・UIKitまとめ

### DIFF
--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -1,6 +1,7 @@
 %header.flex-start.belt
-	#header-left.icon
+	#header-left.icon.flex-center
 	#header-center.grow.flex-center
 		.text SCS Portal
-	#header-right.icon
+	#header-right.icon.flex-center
+		%span{ 'uk-icon': 'grid', ratio: 1.6, style: 'fill:white'}
 


### PR DESCRIPTION
以下内容の変更です。
・UIkitの実装用CSSフォルダを削除し、scsportal-uikit.cssというファイルにまとめて、application.cssでインポートする作りにしました。
・ヘッダーのメニューアイコンをクリックすると操作メニューが表示されるようになりました。